### PR TITLE
MyLists duplication after admin edit resolved

### DIFF
--- a/Class Diagram/Gateways/UserGateway.cs
+++ b/Class Diagram/Gateways/UserGateway.cs
@@ -86,12 +86,18 @@ namespace DataModels.Gateways
         {
             string salt = GetRandomPasswordSalt();
             string hash = Sha256(salt + pwd);
+            List<MyLists> newList = new List<MyLists>
+            {
+                new MyLists() {TitleOfList = "Wish List", Games = new List<Game>()},
+                new MyLists() {TitleOfList = "Favourite List", Games = new List<Game>()}
+            };
             var user = new User
             {
                 AccountRole = role,
                 Email = email,
                 Gender = gender,
                 Password = hash,
+                MyLists = newList,
                 Salt = salt
             };
             await this.Insert(user);

--- a/Class Diagram/User.cs
+++ b/Class Diagram/User.cs
@@ -19,11 +19,7 @@ namespace DataModels
         [JsonConverter(typeof(StringEnumConverter))]
         public DataModels.Gender Gender { get; set; }
 
-        public List<MyLists> MyLists { get; set; } = new List<MyLists>()
-        {
-            new MyLists() {TitleOfList = "Wish List", Games = new List<Game>()},
-            new MyLists() {TitleOfList = "Favourite List", Games = new List<Game>()}
-        };
+        public List<MyLists> MyLists { get; set; } = new List<MyLists>();
         [JsonConverter(typeof(StringEnumConverter))]
         public AccountRole AccountRole { get; set; }
 


### PR DESCRIPTION
User only gets lists in the register method, not in the user model anymore. This prevents that the user gets +2 lists each time the admin edits the user.